### PR TITLE
Add Amazon CAs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,3 +51,11 @@ public_key_pinning:
         - NguuvB5WoODUZEl9eI35tPVrsvqNff0iK2BqLI/cd0A=
         - dS7lkSs8Ft7kDjlx49qoiCd+KmZO5dczUy9b3SZxUK8=
         - CjM6HMDUvUtK0w25dTW/t39bDs0aK8hOHOAsnq2DHMU=
+        # Amazon Root CA 1
+        - ++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=
+        # Amazon Root CA 2
+        - f0KW/FtqTjs108NpYj42SrGvOB2PpxIVM8nWxjPqJGE=
+        # Amazon Root CA 3
+        - NqvDJlas/GRcYbcWE8S/IceH9cq77kg0jVhZeAPXq8k=
+        # Amazon Root CA 4
+        - 9+ze1cZgR9KO1kZrVDxA4HQ6voHRCSVNz4RdTCx4U8U=


### PR DESCRIPTION
Add base64 encoded SHA256 checksums of [Amazon CA certificates](https://www.amazontrust.com/repository/):

```
import binascii


def sha256_as_base64(h):
    hex = h.decode("hex")
    return binascii.b2a_base64(hex)


CERTIFICATES = {
    "Amazon Root CA 1" : "fbe3018031f9586bcbf41727e417b7d1c45c2f47f93be372a17b96b50757d5a2",
    "Amazon Root CA 2" : "7f4296fc5b6a4e3b35d3c369623e364ab1af381d8fa7121533c9d6c633ea2461",
    "Amazon Root CA 3" : "36abc32656acfc645c61b71613c4bf21c787f5cabbee48348d58597803d7abc9",
    "Amazon Root CA 4" : "f7ecded5c66047d28ed6466b543c40e0743abe81d109254dcf845d4c2c7853c5"
}

for name, sha256 in CERTIFICATES.iteritems():
    print name, sha256_as_base64(sha256),
```

**Output**:
```
Amazon Root CA 4 9+ze1cZgR9KO1kZrVDxA4HQ6voHRCSVNz4RdTCx4U8U=
Amazon Root CA 1 ++MBgDH5WGvL9Bcn5Be30cRcL0f5O+NyoXuWtQdX1aI=
Amazon Root CA 2 f0KW/FtqTjs108NpYj42SrGvOB2PpxIVM8nWxjPqJGE=
Amazon Root CA 3 NqvDJlas/GRcYbcWE8S/IceH9cq77kg0jVhZeAPXq8k=
```